### PR TITLE
Updating CI to run tests on Ubuntu Bionic, the version site_bot now runs on when deployed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-# Site bot's current host is running on Trusty
-dist: trusty
+# Site bot's current host is running on Ubuntu Bionic (18.04)
+dist: bionic
 language: python
 python:
 - '2.7'


### PR DESCRIPTION
I've updated the host that site_bot runs on AWS to Ubuntu Bionic.