### PR TITLE
Maintaining datetimes as datetime types, so that Jekyll can compare datetimes

### DIFF
--- a/app/Meetup/Event.py
+++ b/app/Meetup/Event.py
@@ -8,7 +8,7 @@ class MeetupEvent:
             'category': 'Events',
             'layout': 'event',
             'title': "%s %s" % (event['time'].strftime('%B %d'), event['title']),
-            'event_date': "%s" % event['time'],
+            'event_date': event['time'],
             'meetup_event_id': event['id'],
             'source_meetup_content': True,
             'venue_name': event['venue_name'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.0
 beautifulsoup4==4.5.3
 certifi==2019.9.11
 chardet==3.0.4
-Faker==0.7.7
+Faker==2.0.3
 feedparser==5.2.1
 funcsigs==1.0.2
 icalendar==4.0.3
@@ -20,5 +20,6 @@ PyYAML==5.1.2
 requests==2.20.0
 requests-mock==1.2.0
 six==1.10.0
+text-unidecode==1.3
 typing==3.5.3.0
 urllib3==1.24.3

--- a/tests/site_bot_test_helper.py
+++ b/tests/site_bot_test_helper.py
@@ -16,7 +16,7 @@ class SiteBotTestCase(unittest.TestCase):
         return {
             'id': self.fake.random_number(),
             'title': self.fake.sentence(4),
-            'time': self.fake.date_time_this_year(True, True),
+            'time': self.fake.date_time_this_year(),
             'excerpt': self.fake.sentence(4),
             'venue_name': self.fake.company(),
             'venue_location': self.fake.street_address()

--- a/tests/test_meetup_event.py
+++ b/tests/test_meetup_event.py
@@ -44,7 +44,7 @@ class MeetupEventTest(SiteBotTestCase):
             "category: Events",
             "layout: event",
             "title: %s" % expected_frontmatter['title'],
-            "event_date: '%s'" % expected_frontmatter['event_date'],
+            "event_date: %s" % expected_frontmatter['event_date'],
             "meetup_event_id: %s" % expected_frontmatter['meetup_event_id'],
             "source_meetup_content: true",
             "venue_name: %s" % expected_frontmatter['venue_name'],


### PR DESCRIPTION
This prevents Jekyll builds of the Open Twin Cities site from failing due to datetime/String comparisons